### PR TITLE
OEMID clarifications and references

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -86,12 +86,14 @@ normative:
     target: http://www.iana.org/assignments/cwt
     author: 
     - org: IANA
+    date: false
 
   IANA.JWT.Claims:
      title: JSON Web Token (JWT) Claims
      author: 
      - org: IANA
      target: https://www.iana.org/assignments/jwt
+     date: false
  
 informative:
   Webauthn:
@@ -128,14 +130,17 @@ informative:
   OUI.Lookup:
     title: IEEE Registration Authority Assignments
     target: https://regauth.standards.ieee.org/standards-ra-web/pub/view.html#registries
+    date: false
 
   IEEE.RA:
     title: IEEE Registration Authority
     target: https://standards.ieee.org/products-services/regauth/index.html
+    date: false
 
   IEEE.802-2001:
     title: IEEE Standard For Local And Metropolitan Area Networks Overview And Architecture
     target: https://webstore.ansi.org/standards/ieee/ieee8022001r2007
+    date: 2007
 
 
 --- abstract

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -494,34 +494,34 @@ in CWT in that it describes the authority that created the token.
     origination_claim = (
     origination: string_or_uri )
 
-## OEM identification by IEEE (oemid)
+## OEM Identification by IEEE (oemid)
 
 The IEEE operates a global registry for MAC addresses and company IDs.
 This claim uses that database to identify OEMs. The contents of the
-claim may be either an IEEE MA-L, MA-M, MA-S or an IEEE CID {{IEEE.RA}}. 
-An MA-L, formerly known as an OUI, is a 24-bit value used as the first
-half of a MAC address. MA-M similarly is a 28-bit value uses as the first
-part of a MAC address, and MA-S, formerly known as OUI-36, a 36-value. 
-Many companies already have purchased one of these. A CDI is also
-a 24-bit value from the same space as an MA-L, but not for use as a MAC address.
-IEEE has published Guidelines for Use of EUI, OUI, and CID {{OUI.Guide}} and
-provides a lookup services {{OUI.Lookup}}
+claim may be either an IEEE MA-L, MA-M, MA-S or an IEEE CID
+{{IEEE.RA}}.  An MA-L, formerly known as an OUI, is a 24-bit value
+used as the first half of a MAC address. MA-M similarly is a 28-bit
+value uses as the first part of a MAC address, and MA-S, formerly
+known as OUI-36, a 36-value.  Many companies already have purchased
+one of these. A CID is also a 24-bit value from the same space as an
+MA-L, but not for use as a MAC address.  IEEE has published Guidelines
+for Use of EUI, OUI, and CID {{OUI.Guide}} and provides a lookup
+services {{OUI.Lookup}}
 
-Companies that have more than one of these IDs or MAC address blocks should
-pick one and prefer that for all their devices.
+Companies that have more than one of these IDs or MAC address blocks
+should pick one and prefer that for all their devices.
 
-Commonly, these are expressed in Hexadecimal Representation {{IEEE.802-2001}} 
-also called the Canonical format. When this claim is encoded this is the
-byte order used. 
-
-These claims use the hex_bstr type. It encodes as a binary byte string in
-CDDL for compactness and a hexadecimal text in JSON for readability. The JSON
-representation is not base64 encoded as used for other binary data. 
+Commonly, these are expressed in Hexadecimal Representation
+{{IEEE.802-2001}} also called the Canonical format. When this claim is
+encoded order of bytes in the bstr are the same as the order in the
+Hexadecimal Representation. For example, an MA-L like "AC-DE-48" would
+be encoded in 3 bytes with values 0xAC, 0xDE, 0x48. For JSON encoded
+tokens, this is further base64url encoded.
 
 ### CDDL
 
     oemid_claim = (
-    oemid: hex_bstr )
+    oemid: bstr )
 
 
 ## The Security Level Claim (security_level)
@@ -826,7 +826,6 @@ following CDDL types are encoded in JSON as follows:
 * bstr -- must be base64url encoded
 * time -- must be encoded as NumericDate as described section 2 of {{RFC7519}}.
 * string_or_uri -- must be encoded as StringOrURI as described section 2 of {{RFC7519}}.
-* hex_bstr -- encoded as hexadecimal text separated by ":" or "-". For example "“AC-DE-48-23" or "“AC:DE:48:23"
 
 ## CBOR
 
@@ -851,11 +850,6 @@ following CDDL types are encoded in JSON as follows:
     altitude_accuracy = 5
     heading = 6
     speed = 7
-
-### CBOR Types
-
-* hex_bstr -- This is encoded as a standard CBOR byte string. 
-
 
 ### CBOR Interoperability
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -92,7 +92,7 @@ normative:
      author: 
      - org: IANA
      target: https://www.iana.org/assignments/jwt
-
+ 
 informative:
   Webauthn:
     title: 'Web Authentication: A Web API for accessing scoped credentials'
@@ -119,6 +119,23 @@ informative:
     title: Ecma International, "ECMAScript Language Specification, 5.1 Edition", ECMA Standard 262
     date:  June 2011
     target: http://www.ecma-international.org/ecma-262/5.1/ECMA-262.pdf
+
+  OUI.Guide:
+    title: Guidelines for Use of Extended Unique Identifier (EUI), Organizationally Unique Identifier (OUI), and Company ID (CID)
+    date: August 2017
+    target: https://standards.ieee.org/content/dam/ieee-standards/standards/web/documents/tutorials/eui.pdf
+
+  OUI.Lookup:
+    title: IEEE Registration Authority Assignments
+    target: https://regauth.standards.ieee.org/standards-ra-web/pub/view.html#registries
+
+  IEEE.RA:
+    title: IEEE Registration Authority
+    target: https://standards.ieee.org/products-services/regauth/index.html
+
+  IEEE.802-2001:
+    title: IEEE Standard For Local And Metropolitan Area Networks Overview And Architecture
+    target: https://webstore.ansi.org/standards/ieee/ieee8022001r2007
 
 
 --- abstract
@@ -477,24 +494,34 @@ in CWT in that it describes the authority that created the token.
     origination_claim = (
     origination: string_or_uri )
 
-## OEM identification by IEEE OUI (oemid)
+## OEM identification by IEEE (oemid)
 
-This claim identifies a device OEM by the IEEE OUI. Reference TBD. It
-is a byte string representing the OUI in binary form in network byte
-order (TODO: confirm details).
+The IEEE operates a global registry for MAC addresses and company IDs.
+This claim uses that database to identify OEMs. The contents of the
+claim may be either an IEEE MA-L, MA-M, MA-S or an IEEE CID {{IEEE.RA}}. 
+An MA-L, formerly known as an OUI, is a 24-bit value used as the first
+half of a MAC address. MA-M similarly is a 28-bit value uses as the first
+part of a MAC address, and MA-S, formerly known as OUI-36, a 36-value. 
+Many companies already have purchased one of these. A CDI is also
+a 24-bit value from the same space as an MA-L, but not for use as a MAC address.
+IEEE has published Guidelines for Use of EUI, OUI, and CID {{OUI.Guide}} and
+provides a lookup services {{OUI.Lookup}}
 
-Companies that have more than one IEEE OUI registered with IEEE should
-pick one and prefer that for all their devices. 
+Companies that have more than one of these IDs or MAC address blocks should
+pick one and prefer that for all their devices.
 
-Note that the OUI is in common use as a part of MAC Address. This
-claim is only the first bits of the MAC address that identify the
-manufacturer. The IEEE maintains a registry for these in which many
-companies participate.
+Commonly, these are expressed in Hexadecimal Representation {{IEEE.802-2001}} 
+also called the Canonical format. When this claim is encoded this is the
+byte order used. 
+
+These claims use the hex_bstr type. It encodes as a binary byte string in
+CDDL for compactness and a hexadecimal text in JSON for readability. The JSON
+representation is not base64 encoded as used for other binary data. 
 
 ### CDDL
 
     oemid_claim = (
-    oemid: bstr )
+    oemid: hex_bstr )
 
 
 ## The Security Level Claim (security_level)
@@ -799,6 +826,7 @@ following CDDL types are encoded in JSON as follows:
 * bstr -- must be base64url encoded
 * time -- must be encoded as NumericDate as described section 2 of {{RFC7519}}.
 * string_or_uri -- must be encoded as StringOrURI as described section 2 of {{RFC7519}}.
+* hex_bstr -- encoded as hexadecimal text separated by ":" or "-". For example "“AC-DE-48-23" or "“AC:DE:48:23"
 
 ## CBOR
 
@@ -823,6 +851,11 @@ following CDDL types are encoded in JSON as follows:
     altitude_accuracy = 5
     heading = 6
     speed = 7
+
+### CBOR Types
+
+* hex_bstr -- This is encoded as a standard CBOR byte string. 
+
 
 ### CBOR Interoperability
 


### PR DESCRIPTION
Corrected text and references to match up to the IEEE documents and specs.

Defines new encoding type, hex_bstr, that encodes to bstr in CBOR for compactness and hexadecimal text in JSON for readability.

This is to address #38