### PR TITLE
Add CDDL group socket to the top-level eat map

### DIFF
--- a/cddl/cwt.cddl
+++ b/cddl/cwt.cddl
@@ -1,10 +1,12 @@
-rfc8392-claim //= ( issuer => text )
-rfc8392-claim //= ( subject => text )
-rfc8392-claim //= ( audience => text )
-rfc8392-claim //= ( expiration => time )
-rfc8392-claim //= ( not-before => time )
-rfc8392-claim //= ( issued-at => time )
-rfc8392-claim //= ( cwt-id => bytes )
+$$eat-extension //= (
+    ? issuer => text,
+    ? subject => text,
+    ? audience => text,
+    ? expiration => time,
+    ? not-before => time,
+    ? issued-at => time,
+    ? cwt-id => bytes,
+)
 
 issuer = 1
 subject = 2
@@ -14,4 +16,3 @@ not-before = 5
 issued-at = 6
 cwt-id = 7
 
-cwt-claim = rfc8392-claim

--- a/cddl/eat.cddl
+++ b/cddl/eat.cddl
@@ -9,8 +9,7 @@ eat-claims = { ; the top-level payload that is signed using COSE or JOSE
     ? location-claim,
     ? uptime-claim,
     ? submods-part,
-    ? cwt-claim,
-;    ? generic-claim-type,
+    * $$eat-extension,
 }
 
 eat-token = EAT_Tagged ; This is a set of eat-claims signed using COSE

--- a/cddl/examples/simple.diag
+++ b/cddl/examples/simple.diag
@@ -1,4 +1,5 @@
 {
+    / issuer /           1: "joe",
     / nonce /           10: h'948f8860d13a463e8e',
     / UEID /            11: h'0198f50a4ff6c05861c8860d13a638ea4fe2fa',
     / secure-boot /     15: true,


### PR DESCRIPTION
The extension mechanism is bootstrapped with the CWT claims set

Fixes #77