### PR TITLE
Use CoAP Content format for swevidence and manifest claims

### DIFF
--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -6,7 +6,6 @@ include vars.mk
 %.cbor: %.diag ; @$(diag2cbor) $< > $@
 
 DIAG_EXAMPLES := $(wildcard examples/*.diag)
-;DIAG_EXAMPLES := $(wildcard examples/valid_key_store.diag)
 CBOR_EXAMPLES := $(DIAG_EXAMPLES:.diag=.cbor)
 
 CLEANFILES += $(CBOR_EXAMPLES)

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -6,6 +6,7 @@ include vars.mk
 %.cbor: %.diag ; @$(diag2cbor) $< > $@
 
 DIAG_EXAMPLES := $(wildcard examples/*.diag)
+;DIAG_EXAMPLES := $(wildcard examples/valid_key_store.diag)
 CBOR_EXAMPLES := $(DIAG_EXAMPLES:.diag=.cbor)
 
 CLEANFILES += $(CBOR_EXAMPLES)
@@ -38,7 +39,7 @@ $(JSON_CDDL_FOR_DOCUMENT): $(JSON_CDDL_FRAGS)
 	done > $@
 
 
-$(CDDL_FOR_CBOR_VALIDATION): $(VALIDATION_CBOR_CDDL) cose-stub.cddl concise-swid-tag.cddl coswid-tag-stub.cddl
+$(CDDL_FOR_CBOR_VALIDATION): $(VALIDATION_CBOR_CDDL) cose-stub.cddl concise-swid-tag.cddl coswid-tag-stub.cddl  draft-ietf-suit-manifest.cddl
 	@for f in $^ ; do \
 		( cat $$f ; echo ) ; \
 	done > $@

--- a/cddl/coswid-tag-stub.cddl
+++ b/cddl/coswid-tag-stub.cddl
@@ -3,6 +3,8 @@ unsigned-coswid = concise-swid-tag / tagged-coswid<concise-swid-tag>
 signed-coswid1 = signed-coswid-for<unsigned-coswid>
 signed-coswid = signed-coswid1 / tagged-coswid<signed-coswid1>
 
+untagged-coswid  = concise-swid-tag
+
 tagged-coswid<T> = #6.1398229316(T)
 
 signed-coswid-for<payload> = #6.18(COSE-Sign1-coswid<payload>)

--- a/cddl/examples/valid_key_store.diag
+++ b/cddl/examples/valid_key_store.diag
@@ -24,11 +24,12 @@
     / secure-boot /    262: true,
     / debug-status /   263: 2, / disabled-since-boot /
     / manifests /      273: [
-                                h'da53574944a600683762623334383766
+                                [700, / CoAP Content tag for CoSWID /
+                                h'a600683762623334383766
                                   0c000169436172626f6e6974650d6331
                                   2e320e0102a2181f75496e6475737472
                                   69616c204175746f6d6174696f6e1821
-                                  02'
+                                  02' ]
                                  / Above is an encoded CoSWID     /
 				 / with the following data        /
                                  /   SW Name: "Carbonite"         /
@@ -54,14 +55,14 @@
          / nonce /             10: h'948f8860d13a463e',
            / security-level / 261: 1, / unrestricted /
            / secure-boot /    262: true,
-           / manifests /      273: [
-                                    h'da53574944a600687337
+           / manifests /      273: [ [ 900,
+                                    h'a600687337
                                       6537346b78380c000168
                                       44726f6964204f530d65
                                       52322e44320e0302a218
                                       1F75496E647573747269
                                       616c204175746f6d6174
-                                      696f6e182102'
+                                      696f6e182102' ]
                                      / Above is an encoded CoSWID /
                                      / with the following data:   /
 				     /   SW Name: "Droid OS"      /

--- a/cddl/examples/valid_key_store.diag
+++ b/cddl/examples/valid_key_store.diag
@@ -24,12 +24,15 @@
     / secure-boot /    262: true,
     / debug-status /   263: 2, / disabled-since-boot /
     / manifests /      273: [
-                                [700, / CoAP Content tag for CoSWID /
-                                h'a600683762623334383766
-                                  0c000169436172626f6e6974650d6331
-                                  2e320e0102a2181f75496e6475737472
-                                  69616c204175746f6d6174696f6e1821
-                                  02' ]
+                                [ 121, / CoAP Content ID. A      /
+                                       / made up one until one   /
+                                       / is assigned for CoSWID  /
+                                  h'a600683762623334383766
+                                    0c000169436172626f6e6974650d6331
+                                    2e320e0102a2181f75496e6475737472
+                                    69616c204175746f6d6174696f6e1821
+                                    02'
+                                 ]
                                  / Above is an encoded CoSWID     /
 				 / with the following data        /
                                  /   SW Name: "Carbonite"         /
@@ -55,20 +58,24 @@
          / nonce /             10: h'948f8860d13a463e',
            / security-level / 261: 1, / unrestricted /
            / secure-boot /    262: true,
-           / manifests /      273: [ [ 900,
+           / manifests /      273: [ 
+                                [ 121, / CoAP Content ID. A      /
+                                       / made up one until one   /
+                                       / is assigned for CoSWID  /
                                     h'a600687337
                                       6537346b78380c000168
                                       44726f6964204f530d65
                                       52322e44320e0302a218
                                       1F75496E647573747269
                                       616c204175746f6d6174
-                                      696f6e182102' ]
-                                     / Above is an encoded CoSWID /
-                                     / with the following data:   /
-				     /   SW Name: "Droid OS"      /
-                                     /   SW Vers: "R2.D2"         /
-                                     /   SW Creator:              /
-                                     /     "Industrial Automation"/
+                                      696f6e182102' 
+                                  ]
+                                  / Above is an encoded CoSWID /
+                                  / with the following data:   /
+				  /   SW Name: "Droid OS"      /
+                                  /   SW Vers: "R2.D2"         /
+                                  /   SW Creator:              /
+                                  /     "Industrial Automation"/
                                ]
                            }
                        }

--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -4,6 +4,8 @@ $$claims-set-claims //= (
 
 manifests-type = [+ manifest-format]
 
+; TODO: switch to JC<> macro
+
 manifest-format = [
     content-type:   uint, ; CoAP Content Format
     content-format: $$manifest-body-json .feature "J" /

--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -10,18 +10,27 @@ manifest-format = [
                     $$manifest-body-cbor .feature "C"
 ]
 
-; The JSON and CBOR types for CoSWID
-; When a CoSWID occurs in a JSON token it is an untagged-coswid 
-; encoded in CBOR as usual, but then wrapped with B64 encoding.
+; The JSON and CBOR types for CoSWID. CoSWIDs are of course alwas in
+; CBOR format. When a CoSWID occurs in a CBOR token, it is bstr
+; wrapped.  When a CoSWID occurs in a JSON token it is an
+; untagged-coswid encoded in CBOR as usual, but then wrapped with B64
+; encoding.
+;
 $$manifest-body-cbor /= bytes .cbor untagged-coswid
 $$manifest-body-json /= base64-url-text
 
 
-; The JSON and CBOR types for SUIT Manifest
-; TODO fix this
-;$$manifest-body-cbor /= bytes .cbor SUIT_Envelope
+; A SUIT manifest is always CBOR, so the same is done for it as is
+; done for a CoSWID.
+;
+$$manifest-body-cbor /= bytes .cbor SUIT_Envelope
 $$manifest-body-json /= base64-url-text
 
-; TODO remove this when fully merged 
+
+; TODO: remove this when SUIT CDDL gets fixed
+suit-directive-process-dependency = 19
+
+
+; TODO remove this when merged with other PR that defines it
 base64-url-text = text
 

--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -2,13 +2,26 @@ $$claims-set-claims //= (
     manifests-label => manifests-type
 )
 
-manifests-type = [+ $$manifest-formats]
+manifests-type = [+ manifest-format]
 
-; Must be a CoSWID payload type
-; TODO: signed CoSWIDs
-coswid-that-is-a-cbor-tag-xx = tagged-coswid<concise-swid-tag>
+manifest-format = [
+    content-type:   uint, ; CoAP Content Format
+    content-format: $$manifest-body-json .feature "J" /
+                    $$manifest-body-cbor .feature "C"
+]
 
-$$manifest-formats /= bytes .cbor coswid-that-is-a-cbor-tag-xx
+; The JSON and CBOR types for CoSWID
+; When a CoSWID occurs in a JSON token it is an untagged-coswid 
+; encoded in CBOR as usual, but then wrapped with B64 encoding.
+$$manifest-body-cbor /= bytes .cbor untagged-coswid
+$$manifest-body-json /= base64-url-text
 
-; TODO: make this work too
-;$$manifest-formats /= bytes .cbor SUIT_Envelope_Tagged
+
+; The JSON and CBOR types for SUIT Manifest
+; TODO fix this
+;$$manifest-body-cbor /= bytes .cbor SUIT_Envelope
+$$manifest-body-json /= base64-url-text
+
+; TODO remove this when fully merged 
+base64-url-text = text
+

--- a/cddl/swevidence.cddl
+++ b/cddl/swevidence.cddl
@@ -2,9 +2,18 @@ $$claims-set-claims //= (
     swevidence-label => swevidence-type
 )
 
-swevidence-type = [+ $$swevidence-formats]
+swevidence-type = [+ swevidence-format]
 
-; Must be a CoSWID evidence type that is a CBOR tag
-; TODO: fix the CDDL so a signed CoSWID is allowed too 
-coswid-that-is-a-cbor-tag = tagged-coswid<concise-swid-tag>
-$$swevidence-formats /= bytes .cbor coswid-that-is-a-cbor-tag 
+swevidence-format = [
+    content-type:   uint, ; CoAP Content Format
+    content-format: $$swevidence-body-json .feature "J" /
+                    $$swevidence-body-cbor .feature "C"
+]
+
+; The JSON and CBOR types for CoSWID
+; When a CoSWID occurs in a JSON token it is an untagged-coswid 
+; encoded in CBOR as usual, but then wrapped with B64 encoding.
+$$swevidence-body-cbor /= bytes .cbor untagged-coswid
+$$swevidence-body-json /= base64-url-text
+
+

--- a/cddl/swevidence.cddl
+++ b/cddl/swevidence.cddl
@@ -10,9 +10,12 @@ swevidence-format = [
                     $$swevidence-body-cbor .feature "C"
 ]
 
-; The JSON and CBOR types for CoSWID
-; When a CoSWID occurs in a JSON token it is an untagged-coswid 
-; encoded in CBOR as usual, but then wrapped with B64 encoding.
+; The JSON and CBOR types for CoSWID. CoSWIDs are of course alwas in
+; CBOR format. When a CoSWID occurs in a CBOR token, it is bstr
+; wrapped.  When a CoSWID occurs in a JSON token it is an
+; untagged-coswid encoded in CBOR as usual, but then wrapped with B64
+; encoding.
+;
 $$swevidence-body-cbor /= bytes .cbor untagged-coswid
 $$swevidence-body-json /= base64-url-text
 

--- a/cddl/swevidence.cddl
+++ b/cddl/swevidence.cddl
@@ -4,6 +4,8 @@ $$claims-set-claims //= (
 
 swevidence-type = [+ swevidence-format]
 
+; TODO: switch to JC<> macro when 
+
 swevidence-format = [
     content-type:   uint, ; CoAP Content Format
     content-format: $$swevidence-body-json .feature "J" /

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -925,7 +925,7 @@ The method of constructing the registrar URI, platform label and possibly applic
 ~~~~
 
 
-### The Software Manifests Claim (manifests)
+### The Software Manifests Claim (manifests) {#manifests}
 
 This claim contains descriptions of software present on the entity.
 These manifests are installed on the entity when the software is installed or are created as part of the installation process.
@@ -968,10 +968,11 @@ This claim contains descriptions, lists, evidence or measurements of the softwar
 The defining characteristic of this claim is that its contents are created by processes on the entity that inventory, measure or otherwise characterize the software on the entity.
 The contents of this claim do not originate from the software manufacturer.
 
-This claim uses the same mechanism for identification of the type of the swevidence as is used for the type of the manifest in the manifests claim.
-See the discussion above in the manifests claim.
+This claim can be a {{CoSWID}}.
+When the CoSWID format is used, it MUST be evidence CoSWIDs, not payload CoSWIDS.
 
-When the {{CoSWID}} format is used, it MUST be evidence CoSWIDs, not payload CoSWIDS.
+Formats other than CoSWID can be used.
+The identification of format is by CoAP Content Format, the same as the manifests claim in {{manifests}}.
 
 ~~~~CDDL
 {::include nc-cddl/swevidence.cddl}

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -51,6 +51,7 @@ normative:
   RFC7515:
   RFC7516:
   RFC8949:
+  RFC7252:
   RFC7517:
   RFC7519:
   RFC7800:
@@ -938,31 +939,21 @@ For example, the manifest might be a CoSWID signed by the software manufacturer,
 
 This claim allows multiple formats for the manifest.
 For example, the manifest may be a CBOR-format CoSWID, an XML-format SWID or other.
-Identification of the type of manifest is always by a CBOR tag.
-In many cases, for examples CoSWID, a tag will already be registered with IANA.
-If not, a tag MUST be registered.
-It can be in the first-come-first-served space which has minimal requirements for registration.
+Identification of the type of manifest is always by a CoAP Content-Format integer. {{RFC7252}}
+If there is no CoAP identifier registered for the manifest format, one should be registered, perhaps in the experimental or first-come-first-served range.
 
-The claim is an array of one or more manifests.
-To facilitate hand off of the manifest to a decoding library, each manifest is contained in a byte string.
-This occurs for CBOR-format manifests as well as non-CBOR format manifests.
+This claim MUST be an array of one or more manifests.
+Each manifest in the claim MUST be an array of two.
+The first item in the array of two MUST be an integer CoAP Content-Format identifier.
+The second item is MUST be the actual manifest.
 
-If a particular manifest type uses CBOR encoding, then the item in the array for it MUST be a byte string that contains a CBOR tag.
-The EAT decoder must decode the byte string and then the CBOR within it to find the tag number to identify the type of manifest.
-The contents of the byte string is then handed to the particular manifest processor for that type of manifest.
-CoSWID and SUIT manifest are examples of this.
+In CBOR-encoded EATs the manifest, whatever format it is, MUST be placed in a byte string.
 
-If a particular manifest type does not use CBOR encoding, then the item in the array for it MUST be a CBOR tag that contains a byte string.
-The EAT decoder uses the tag to identify the processor for that type of manifest.
-The contents of the tag, the byte string, are handed to the manifest processor.
-Note that a byte string is used to contain the manifest whether it is a text based format or not.
-An example of this is an XML format ISO/IEC 19770 SWID.
-
-It is not possible to describe the above requirements in CDDL, so the type for an individual manifest is any in the CDDL below.
-The above text sets the encoding requirement.
+In JSON-format tokens the manifest, whatever format it is, MUST be placed in a text string.
+When a non-text format manifest like a CBOR-encoded CoSWID is put in a JSON-encoded token, the manifest MUST be base-64 encoded.
 
 This claim allows for multiple manifests in one token since multiple software packages are likely to be present.
-The multiple manifests MAY be of multiple formats.
+The multiple manifests MAY be of different formats.
 In some cases EAT submodules may be used instead of the array structure in this claim for multiple manifests.
 
 When the {{CoSWID}} format is used, it MUST be a payload CoSWID, not an evidence CoSWID.
@@ -978,7 +969,6 @@ The defining characteristic of this claim is that its contents are created by pr
 The contents of this claim do not originate from the software manufacturer.
 
 This claim uses the same mechanism for identification of the type of the swevidence as is used for the type of the manifest in the manifests claim.
-It also uses the same byte string based mechanism for containing the claim and easing the hand off to a processing library.
 See the discussion above in the manifests claim.
 
 When the {{CoSWID}} format is used, it MUST be evidence CoSWIDs, not payload CoSWIDS.

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -939,7 +939,7 @@ For example, the manifest might be a CoSWID signed by the software manufacturer,
 
 This claim allows multiple formats for the manifest.
 For example, the manifest may be a CBOR-format CoSWID, an XML-format SWID or other.
-Identification of the type of manifest is always by a CoAP Content-Format integer. {{RFC7252}}
+Identification of the type of manifest is always by a CoAP Content-Format integer {{RFC7252}}.
 If there is no CoAP identifier registered for the manifest format, one should be registered, perhaps in the experimental or first-come-first-served range.
 
 This claim MUST be an array of one or more manifests.
@@ -2779,3 +2779,6 @@ no new claims have been added.
 
 * Clarify manufacturer switching UEID types
 
+## From draft-ietf-rats-eat-11
+
+* Use CoAP content format ID to distinguish manifest and evidence formats instead of CBOR tag


### PR DESCRIPTION
Address #177. 

Previous text was broken for JSON tokens and this seems like a much better and more universal design.