### PR TITLE
correct JSON label for profile claim

### DIFF
--- a/cddl/claim-labels.cddl
+++ b/cddl/claim-labels.cddl
@@ -10,7 +10,7 @@ hardware-version-label = JC< "hwvers",     260 >
 secure-boot-label      = JC< "secboot",    262 >
 debug-status-label     = JC< "dbgstat",    263 >
 location-label         = JC< "location",   264 >
-profile-label          = JC< "profile",    265 >
+profile-label          = JC< "eat_profile",265 >
 submods-label          = JC< "submods",    266 >
 
 


### PR DESCRIPTION
There is already a profile claim registered for JWT that serves a different purpose so the "profile" label can't be used.

It was called "eat_profile" in previous drafts, but got unfixed, so the change puts it back correct.