### PR TITLE
improve OID regex

### DIFF
--- a/cddl/common-types.cddl
+++ b/cddl/common-types.cddl
@@ -14,7 +14,7 @@ general-oid = JC< json-oid, ~oid >
 
 ; This is a normative definition for the encoding of an OID
 ; as a text string in JSON as used by EAT
-json-oid = tstr .regexp "[0-9\.]+"
+json-oid = tstr .regexp "([0-2])((\.0)|(\.[1-9][0-9]*))*"
 
 
 ; URI for both JSON and CBOR


### PR DESCRIPTION
This change tightens the regex for matching OIDs, which is currently too lax (for example, it allows "...", "1..2", "1.2.", etc. to successfully validate.)
