### PR TITLE
CDDL type for CoAP Content Format

### DIFF
--- a/cddl/common-types.cddl
+++ b/cddl/common-types.cddl
@@ -19,3 +19,8 @@ json-oid = tstr .regexp "[0-9\.]+"
 
 ; URI for both JSON and CBOR
 general-uri = JC< text, ~uri >
+
+
+; CoAP Content-Format from RFC 7252 section 12.3
+coap-content-format = uint .le 65535
+

--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -5,7 +5,7 @@ $$Claims-Set-Claims //= (
 manifests-type = [+ manifest-format]
 
 manifest-format = [
-    content-type:   uint, ; CoAP Content Format
+    content-type:   coap-content-format,
     content-format: JC< $$manifest-body-json, 
                         $$manifest-body-cbor >
 ]

--- a/cddl/swevidence.cddl
+++ b/cddl/swevidence.cddl
@@ -5,7 +5,7 @@ $$Claims-Set-Claims //= (
 swevidence-type = [+ swevidence-format]
 
 swevidence-format = [
-    content-type:   uint, ; CoAP Content Format
+    content-type:   coap-content-format,
     content-format: JC< $$swevidence-body-json,
                         $$swevidence-body-cbor > 
 ]


### PR DESCRIPTION
Make a CDDL type for CoAP Content-Format and limit it's value to the range in the CoAP RFC.