### PR TITLE
Finalize abstract

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -237,13 +237,11 @@ informative:
 
 An Entity Attestation Token (EAT) provides an attested claims set
 that describes state and characteristics of an entity,
-a device like a phone, IoT device, network equipment or such.  This claims set is used by a
+a device like a smartphone, IoT device, network equipment or such.  This claims set is used by a
 relying party, server or service to determine how much it wishes to trust the entity.
 
 An EAT is either a CBOR Web Token (CWT) or JSON Web Token (JWT) with attestation-oriented
-claims. To a large degree, all this document does is extend
-CWT and JWT.
-
+claims.
 
 --- middle
 


### PR DESCRIPTION
I'd like to use this thread to finalize the abstract. I won't merge it until us authors are agreed on the final abstract.

This change addresses a comment by Eliot that EAT is more than just extensions to JWT/CWT.

Carl, I looked at your proposed changes #259 and prefer this for the following reasons:
- I reviewed the abstracts of lots of RFCs. They are largely one paragraph.
- The abstract should be easy to read, so not so many acronyms
- Some of the things you are trying to in the abstract should be addressed in section 1.
- I very much want to give the concrete example of devices in the abstract because readers won't know what an entity is

