### PR TITLE
bundles are one encoding format

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1315,14 +1315,14 @@ It is a top-level EAT message like a CWT or JWT.
 It can be occur any place that CWT or JWT messages occur.
 It may also be sent as a submodule.
 
-A detached EAT bundle has two main parts.
+A detached EAT bundle consists of two parts.
 
 The first part is a full top-level token.
 This top-level token MUST have at least one submodule that is a detached digest.
 This top-level token may be either CBOR or JSON-encoded.
 It MAY be a CWT, or JWT but NOT a detached EAT bundle.
 It MAY also be some future-defined token type.
-The same mechanism for distinguishing the type for nested token submodules is used here.
+The same mechanism for distinguishing the type for nested token submodules is employed here.
 
 The second part is a map/object containing the detached Claims-Sets corresponding to the detached digests in the full token.
 When the detached EAT bundle is CBOR-encoded, each detached Claims-Set MUST be CBOR-encoded and wrapped in a byte string.
@@ -2589,7 +2589,7 @@ differences. A comprehensive history is available via the IETF Datatracker's rec
 
 ## From draft-ietf-rats-eat-16
 - Add some references to CBOR and CDDL RFCs when introducing terms, examples, ...
-
+- Clarifications on non-mixing of encoding formats in detached EAT bundles
 
 --- contributor
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1316,15 +1316,15 @@ It may also be sent as a submodule.
 A detached EAT bundle has two main parts.
 
 The first part is a full top-level token.
-This top-level token must have at least one submodule that is a detached digest.
+This top-level token MUST have at least one submodule that is a detached digest.
 This top-level token may be either CBOR or JSON-encoded.
-It may be a CWT, or JWT but not a detached EAT bundle.
-It may also be some future-defined token type.
+It MAY be a CWT, or JWT but NOT a detached EAT bundle.
+It MAY also be some future-defined token type.
 The same mechanism for distinguishing the type for nested token submodules is used here.
 
 The second part is a map/object containing the detached Claims-Sets corresponding to the detached digests in the full token.
-When the detached EAT bundle is CBOR-encoded, each detached Claims-Set must be CBOR-encoded and wrapped in a byte string.
-When the detached EAT bundle is JSON-encoded, each detached Claims-Set must be JSON-encoded and base64url encoded.
+When the detached EAT bundle is CBOR-encoded, each detached Claims-Set MUST be CBOR-encoded and wrapped in a byte string.
+When the detached EAT bundle is JSON-encoded, each detached Claims-Set MUST be JSON-encoded and base64url encoded.
 All the detached Claims-Sets MUST be encoded in the same format as the detached EAT bundle.
 No mixing of encoding formats is allowed for the Claims-Sets in a detached EAT bundle.
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1323,8 +1323,8 @@ It may also be some future-defined token type.
 The same mechanism for distinguishing the type for nested token submodules is used here.
 
 The second part is a map/object containing the detached Claims-Sets corresponding to the detached digests in the full token.
-When the detached EAT bundle is CBOR-encoded, each Claims-Set is wrapped in a byte string.
-When the detached EAT bundle is JSON-encoded, each Claims-Set is base64url encoded.
+When the detached EAT bundle is CBOR-encoded, each detached Claims-Set must be CBOR-encoded and wrapped in a byte string.
+When the detached EAT bundle is JSON-encoded, each detached Claims-Set must be JSON-encoded and base64url encoded.
 All the detached Claims-Sets MUST be encoded in the same format as the detached EAT bundle.
 No mixing of encoding formats is allowed for the Claims-Sets in a detached EAT bundle.
 
@@ -1333,7 +1333,7 @@ The normal rules apply for use or non-use of a tag.
 When it is sent as a submodule, it is always sent as a tag to distinguish it from the other types of nested tokens.
 
 The digests of the detached claims sets are associated with detached Claims-Sets by label/name.
-It is up to the constructor of the detached EAT bundle to ensure the names uniquely identify the detachedclaims sets.
+It is up to the constructor of the detached EAT bundle to ensure the names uniquely identify the detached claims sets.
 Since the names are used only in the detached EAT bundle, they can be very short, perhaps one byte.
 
 ~~~~CDDL


### PR DESCRIPTION
This clarifies that all detached claims sets in a bundle must be the same encoding as the bundle.

That is if the detached EAT bundle is CBOR-encoded, then all the detached claims-sets in it must be CBOR-encoded (and bstr wrapped).  The token with the detached digests doesn't have to be the same though. A sort of working principle here is that in EAT encoding can only be different for whole tokens.

We could make an exception for bundles, but we'd need more protocol elements for JSON-encoded tokens so they could distinguish a JSON-detached claims-set from a CBOR-detached claims set. (The same is not needed for CBOR because the tstr/bstr could be used).

There's no requirement that detached Claims-Sets be carried in a detached EAT bundle. They could be in a multipart MIME for example.  In that case mixing is fine because there are media types.