### PR TITLE
Section 1 wording improvements from Hannes

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -270,8 +270,8 @@ Some examples of entities:
 
 * A Secure Element
 * A TEE
-* A card in a network router
-* A network router, perhaps with each card in the router a submodule
+* A network card in a router
+* A router, perhaps with each network card in the router a submodule
 * An IoT device
 * An individual process
 * An app on a smartphone


### PR DESCRIPTION
This addresses section 1 (1, 1.1, 1.2,...) comments in eat-14_hannes.pdf

It is only a tiny change because:

Most of the proposed changes were covered by or no longer relevant because of the large re writing of section 1 in draft 15.

I didn't think the others were needed.