### PR TITLE
Repair long lines

### DIFF
--- a/cddl/Example-Payloads/submods.json
+++ b/cddl/Example-Payloads/submods.json
@@ -1,26 +1,23 @@
 {
-    "eat_nonce": "lI-IYNE6Rj6O",
-    "ueid":     "AJj1Ck_2wFhhyIYNE6Y46g==",
-    "secboot":  true,
-    "dbgstat":  "disabled-permanently",
-    "iat":      1526542894,
-    "submods": {
-        "Android App Foo" :  {
-            "swname": "Foo.app"
-        },
-
-        "Secure Element Eat" : [
-            "CBOR",
-            "2D3ShEOhASagWGaoCkiUj4hg0TpGPhkBAFABmPUKT_bAWGHIhg0TpjjqGQECGfryGQEFBBkBBvUZAQcDGQEEgmMzLjEBGQEKoWNURUWCL1gg5c-V_ST6txRGdC3VjUPa4XjlX-K5QpGpKRCC_8JjWgtYQPaQywOIZ3-mJKN3X9fLxOhAnsmBa-MvpHRzOw-Ywn-67bvJljuctezAPD41s6_At7NbSV3qwJlxIuqGfwe41es="
-        ],
-
-        "Linux Android": {
-            "swname": "Android"
-        },
-
-        "Subsystem J": [ 
-            "JWT",
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dGVzdGVyIiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6IiJ9.gjw4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
-        ] 
-    }
+   "eat_nonce": "lI-IYNE6Rj6O",
+   "ueid": "AJj1Ck_2wFhhyIYNE6Y46g==",
+   "secboot": true,
+   "dbgstat": "disabled-permanently",
+   "iat": 1526542894,
+   "submods": {
+      "Android App Foo": {
+         "swname": "Foo.app"
+      },
+      "Secure Element Eat": [
+         "CBOR",
+         "2D3ShEOhASagWGaoCkiUj4hg0TpGPhkBAFABmPUKT_bAWGHIhg0TpjjqGQECGfryGQEFBBkBBvUZAQcDGQEEgmMzLjEBGQEKoWNURUWCL1gg5c-V_ST6txRGdC3VjUPa4XjlX-K5QpGpKRCC_8JjWgtYQPaQywOIZ3-mJKN3X9fLxOhAnsmBa-MvpHRzOw-Ywn-67bvJljuctezAPD41s6_At7NbSV3qwJlxIuqGfwe41es="
+      ],
+      "Linux Android": {
+         "swname": "Android"
+      },
+      "Subsystem J": [
+         "JWT",
+         "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dGVzdGVyIiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6IiJ9.gjw4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
+      ]
+   }
 }

--- a/cddl/Example-Payloads/submods.json_f
+++ b/cddl/Example-Payloads/submods.json_f
@@ -1,0 +1,31 @@
+{
+    "eat_nonce": "lI-IYNE6Rj6O",
+    "ueid":     "AJj1Ck_2wFhhyIYNE6Y46g==",
+    "secboot":  true,
+    "dbgstat":  "disabled-permanently",
+    "iat":      1526542894,
+    "submods": {
+        "Android App Foo" :  {
+            "swname": "Foo.app"
+        },
+
+        "Secure Element Eat" : [
+            "CBOR",
+            "2D3ShEOhASagWGaoCkiUj4hg0TpGPhkBAFABmPUKT_bAWGHIhg0Tpjj\
+qGQECGfryGQEFBBkBBvUZAQcDGQEEgmMzLjEBGQEKoWNURUWCL1gg5c-V_ST6txRGdC3\
+VjUPa4XjlX-K5QpGpKRCC_8JjWgtYQPaQywOIZ3-mJKN3X9fLxOhAnsmBa-MvpHRzOw-\
+Ywn-67bvJljuctezAPD41s6_At7NbSV3qwJlxIuqGfwe41es="
+        ],
+
+        "Linux Android": {
+            "swname": "Android"
+        },
+
+        "Subsystem J": [ 
+            "JWT",
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dG\
+VzdGVyIiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6Ii\
+J9.gjw4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
+        ] 
+    }
+}

--- a/cddl/Example-Payloads/submods.json_f
+++ b/cddl/Example-Payloads/submods.json_f
@@ -1,31 +1,28 @@
 {
-    "eat_nonce": "lI-IYNE6Rj6O",
-    "ueid":     "AJj1Ck_2wFhhyIYNE6Y46g==",
-    "secboot":  true,
-    "dbgstat":  "disabled-permanently",
-    "iat":      1526542894,
-    "submods": {
-        "Android App Foo" :  {
-            "swname": "Foo.app"
-        },
-
-        "Secure Element Eat" : [
-            "CBOR",
-            "2D3ShEOhASagWGaoCkiUj4hg0TpGPhkBAFABmPUKT_bAWGHIhg0Tpjj\
-qGQECGfryGQEFBBkBBvUZAQcDGQEEgmMzLjEBGQEKoWNURUWCL1gg5c-V_ST6txRGdC3\
-VjUPa4XjlX-K5QpGpKRCC_8JjWgtYQPaQywOIZ3-mJKN3X9fLxOhAnsmBa-MvpHRzOw-\
-Ywn-67bvJljuctezAPD41s6_At7NbSV3qwJlxIuqGfwe41es="
-        ],
-
-        "Linux Android": {
-            "swname": "Android"
-        },
-
-        "Subsystem J": [ 
-            "JWT",
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dG\
-VzdGVyIiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6Ii\
-J9.gjw4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
-        ] 
-    }
+   "eat_nonce": "lI-IYNE6Rj6O",
+   "ueid": "AJj1Ck_2wFhhyIYNE6Y46g==",
+   "secboot": true,
+   "dbgstat": "disabled-permanently",
+   "iat": 1526542894,
+   "submods": {
+      "Android App Foo": {
+         "swname": "Foo.app"
+      },
+      "Secure Element Eat": [
+         "CBOR",
+         "2D3ShEOhASagWGaoCkiUj4hg0TpGPhkBAFABmPUKT_bAWGHIhg0TpjjqGQ\
+ECGfryGQEFBBkBBvUZAQcDGQEEgmMzLjEBGQEKoWNURUWCL1gg5c-V_ST6txRGdC3VjU\
+Pa4XjlX-K5QpGpKRCC_8JjWgtYQPaQywOIZ3-mJKN3X9fLxOhAnsmBa-MvpHRzOw-Ywn\
+-67bvJljuctezAPD41s6_At7NbSV3qwJlxIuqGfwe41es="
+      ],
+      "Linux Android": {
+         "swname": "Android"
+      },
+      "Subsystem J": [
+         "JWT",
+         "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dGVzd\
+GVyIiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6IiJ9.\
+gjw4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
+      ]
+   }
 }

--- a/cddl/Example-Payloads/valid_hw_block2.diag
+++ b/cddl/Example-Payloads/valid_hw_block2.diag
@@ -12,12 +12,12 @@
     / hwversion /      260: [ "3.1", 1 ], / multipartnumeric /
     / submods/         266: {
                                 "TEE": [ / detached digest submod /
-				    -16, / SHA-256 /
-			            h'e5cf95fd24fab7144674
-				      2dd58d43dae178e55fe2
-				      b94291a9291082ffc2635
-				      a0b'
-				]
-		            }
+                                           -16, / SHA-256 /
+                                           h'e5cf95fd24fab7144674
+                                             2dd58d43dae178e55fe2
+                                             b94291a9291082ffc263
+                                             5a0b'
+                                       ]
+                            }
 }
 

--- a/cddl/Example-Payloads/valid_iot.diag
+++ b/cddl/Example-Payloads/valid_iot.diag
@@ -5,25 +5,25 @@
 / the IoT OS and puts the measurements in the submodule.            /
 
 {
-    / eat_nonce /       10: h'948f8860d13a463e',
-    / secboot /        262: true,
-    / dbgstat /        263: 2, / disabled-since-boot /
-    / oemid /          258: h'8945ad', / IEEE CID based /
-    / ueid /           256: h'0198f50a4ff6c05861c8860d13a638ea', 
-    / submods /        266: {
-                            "OS" : {
-        / secboot /            262: true,
-        / dbgstat /            263: 2, / disabled-since-boot /
-        / measurements         274: [
+    / eat_nonce / 10: h'948f8860d13a463e',
+    / secboot /  262: true,
+    / dbgstat /  263: 2, / disabled-since-boot /
+    / oemid /    258: h'8945ad', / IEEE CID based /
+    / ueid /     256: h'0198f50a4ff6c05861c8860d13a638ea', 
+    / submods /  266: {
+                        "OS" : {
+        / secboot /         262: true,
+        / dbgstat /         263: 2, / disabled-since-boot /
+        / measurements      274: [
                                    [
-                                       121, / CoAP Content ID. A     /
-                                            / made up one until one  /
-                                            / is assigned for CoSWID /
+                                     121, / CoAP Content ID. A     /
+                                          / made up one until one  /
+                                          / is assigned for CoSWID /
 
                                     / This is a byte-string wrapped /
-			            / evidence CoSWID. It has       /
-				    / hashes of the main files of   /
-				    / the IoT OS.  /
+                                    / evidence CoSWID. It has       /
+                                    / hashes of the main files of   /
+                                    / the IoT OS.  /
                                     h'a600663463613234350c
                                       17016d41636d6520522d496f542d4f
                                       530d65332e312e3402a2181f724163
@@ -41,9 +41,9 @@
                                       3d3b0782015820a6a9dcdfb3884da5
                                       f884e4e1e8e8629958c2dbc7027414
                                       43a913e34de9333be6'
-		           	    ]
-                                ]
-			    }
-		        }
+                                   ]
+                                 ]
+                               }
+                            }
 }
 

--- a/cddl/Example-Payloads/valid_key_store.diag
+++ b/cddl/Example-Payloads/valid_key_store.diag
@@ -33,7 +33,7 @@
                                     02'
                                  ]
                                  / Above is an encoded CoSWID     /
-				 / with the following data        /
+                                 / with the following data        /
                                  /   SW Name: "Carbonite"         /
                                  /   SW Vers: "1.2"               /
                                  /   SW Creator:                  /
@@ -70,7 +70,7 @@
                                   ]
                                   / Above is an encoded CoSWID /
                                   / with the following data:   /
-				  /   SW Name: "Droid OS"      /
+                                  /   SW Name: "Droid OS"      /
                                   /   SW Vers: "R2.D2"         /
                                   /   SW Creator:              /
                                   /     "Industrial Automation"/

--- a/cddl/Example-Payloads/valid_results.json
+++ b/cddl/Example-Payloads/valid_results.json
@@ -1,19 +1,22 @@
 {
-    "eat_nonce" : "jkd8KL-8=Qlzg4",
-    "secboot" :  true,
-    "dbgstat" :  "disabled-since-boot",
-    "oemid" :    "iUWt",
-    "ueid" :     "AZj1Ck_2wFhhyIYNE6Y4",
-    "swname" :   "Acme R-IoT-OS",
-    "swversion" : [
-            "3.1.4"
-        ],
-    "measres" : [
-        [
-            "Trustus Measurements",
+   "eat_nonce": "jkd8KL-8=Qlzg4",
+   "secboot": true,
+   "dbgstat": "disabled-since-boot",
+   "oemid": "iUWt",
+   "ueid": "AZj1Ck_2wFhhyIYNE6Y4",
+   "swname": "Acme R-IoT-OS",
+   "swversion": [
+      "3.1.4"
+   ],
+   "measres": [
+      [
+         "Trustus Measurements",
+         [
             [
-                [ "all" , "success" ]
+               "all",
+               "success"
             ]
-       ]
-    ]
+         ]
+      ]
+   ]
 }

--- a/cddl/Example-Payloads/valid_submods.diag
+++ b/cddl/Example-Payloads/valid_submods.diag
@@ -21,7 +21,7 @@
     / oemid /          258: h'894823', / IEEE OUI format OEM ID /
     / hwmodel /        259: h'549dcecc8b987c737b44e40f7c635ce8'
                               / Hash of chip model name /,
-    / hwversion /      260: ["1.3.4", 1], / Multipartnumeric version /
+    / hwversion /      260: ["1.3.4", 1], / Multipartnumeric  /
     / swname /         271: "Acme OS",
     / swversion /      272: ["3.5.5", 1],
     / secboot /        262: true,
@@ -30,16 +30,16 @@
     / submods / 266: {
         / A submodule to hold some claims about the circuit board /
         "board" :  {
-	    / oemid /       258: h'9bef8787eba13e2c8f6e7cb4b1f4619a',
-	    / hwmodel /     259: h'ee80f5a66c1fb9742999a8fdab930893'
-	                              / Hash of board module name /,
-	    / hwversion /   260: ["2.0a", 2] / multipartnumeric+suffix /
+            / oemid /     258: h'9bef8787eba13e2c8f6e7cb4b1f4619a',
+            / hwmodel /   259: h'ee80f5a66c1fb9742999a8fdab930893'
+                                  / Hash of board module name /,
+            / hwversion / 260: ["2.0a", 2] / multipartnumeric+sfx /
         },
 
         / A submodule to hold claims about the overall device /
         "device" :  {
-	    / oemid /       258: 61234, / PEN Format OEM ID / 
-	    / hwversion /   260: ["4.0", 1] / Multipartnumeric version /
+            / oemid /     258: 61234, / PEN Format OEM ID / 
+            / hwversion / 260: ["4.0", 1] / Multipartnumeric /
         }
     }
 }

--- a/cddl/Example-Payloads/valid_tee.diag
+++ b/cddl/Example-Payloads/valid_tee.diag
@@ -5,15 +5,15 @@
     / secboot /        262: true,
     / dbgstat /        263: 2, / disabled-since-boot /
     / manifests /      273: [
-                           [
+                              [
                                121, / CoAP Content ID. A     /
                                     / made up one until one  /
                                     / is assigned for CoSWID /
 
                                / This is byte-string wrapped      /
-			       / payload CoSWID. It gives the TEE /
-			       / software name, the version and   /
-			       / the  name of the file it is in.  /
+                               / payload CoSWID. It gives the TEE /
+                               / software name, the version and   /
+                               / the  name of the file it is in.  /
                                / {0: "3a24",                      /
                                /  12: 1,                          /
                                /   1: "Acme TEE OS",              /
@@ -32,8 +32,6 @@
                                   204f53182101a2181f6b41636d652054
                                   4545204f5318210206a111a118186e61
                                   636d655f7465655f332e657865'
+                              ]
                             ]
-			]
 }
-    
-

--- a/cddl/Example-Tokens/deb.json
+++ b/cddl/Example-Tokens/deb.json
@@ -1,9 +1,10 @@
 [
-    [ "JWT",
+   [
+      "JWT",
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dGVzdGVyIiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6IiJ9.gjw4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
-    ],
-    {
-        "Audio Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgICAgImxJK0lZTkU2Umo2TyIsCiAgICAgICAgICAgICJpYXQiOiAgICAgIDE1MjY1NDI4OTQKICAgICAgICAgfQo=",
-        "Graphics Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgICJsSStJWU5FNlJqNk8iLAogICAgICAgICAgICAiaWF0IjogICAgIDE1MjY1NDI4OTQKICAgICAgICB9"
-    }
+   ],
+   {
+      "Audio Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgICAgImxJK0lZTkU2Umo2TyIsCiAgICAgICAgICAgICJpYXQiOiAgICAgIDE1MjY1NDI4OTQKICAgICAgICAgfQo=",
+      "Graphics Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgICJsSStJWU5FNlJqNk8iLAogICAgICAgICAgICAiaWF0IjogICAgIDE1MjY1NDI4OTQKICAgICAgICB9"
+   }
 ]

--- a/cddl/Example-Tokens/deb.json_f
+++ b/cddl/Example-Tokens/deb.json_f
@@ -1,15 +1,16 @@
 [
-    [ "JWT",
+   [
+      "JWT",
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dGVzdGVy\
 IiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6IiJ9.gjw\
 4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
-    ],
-    {
-        "Audio Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgI\
-CAgImxJK0lZTkU2Umo2TyIsCiAgICAgICAgICAgICJpYXQiOiAgICAgIDE1MjY1NDI4O\
-TQKICAgICAgICAgfQo=",
-        "Graphics Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOi\
-AgICJsSStJWU5FNlJqNk8iLAogICAgICAgICAgICAiaWF0IjogICAgIDE1MjY1NDI4OT\
-QKICAgICAgICB9"
-    }
+   ],
+   {
+      "Audio Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgICA\
+gImxJK0lZTkU2Umo2TyIsCiAgICAgICAgICAgICJpYXQiOiAgICAgIDE1MjY1NDI4OTQ\
+KICAgICAgICAgfQo=",
+      "Graphics Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAg\
+ICJsSStJWU5FNlJqNk8iLAogICAgICAgICAgICAiaWF0IjogICAgIDE1MjY1NDI4OTQK\
+ICAgICAgICB9"
+   }
 ]

--- a/cddl/Example-Tokens/deb.json_f
+++ b/cddl/Example-Tokens/deb.json_f
@@ -1,0 +1,15 @@
+[
+    [ "JWT",
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKLUF0dGVzdGVy\
+IiwiaWF0IjoxNjUxNzc0ODY4LCJleHAiOm51bGwsImF1ZCI6IiIsInN1YiI6IiJ9.gjw\
+4nFMhLpJUuPXvMPzK1GMjhyJq2vWXg1416XKszwQ"
+    ],
+    {
+        "Audio Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOiAgI\
+CAgImxJK0lZTkU2Umo2TyIsCiAgICAgICAgICAgICJpYXQiOiAgICAgIDE1MjY1NDI4O\
+TQKICAgICAgICAgfQo=",
+        "Graphics Subsystem Claims": "ewogICAgICAgICAgICAibm9uY2UiOi\
+AgICJsSStJWU5FNlJqNk8iLAogICAgICAgICAgICAiaWF0IjogICAgIDE1MjY1NDI4OT\
+QKICAgICAgICB9"
+    }
+]

--- a/cddl/Example-Tokens/valid_deb.diag
+++ b/cddl/Example-Tokens/valid_deb.diag
@@ -1,5 +1,6 @@
-/ This is a detached EAT bundle tag.  /
-/ Note that 602, the tag identifying a detached EAT bundle is not yet registered with IANA /
+/ This is a detached EAT bundle tag.  Note that 602, the tag /
+/ identifying a detached EAT bundle is not yet registered /
+/ with IANA /
 
 602([
 

--- a/cddl/debug-status.cddl
+++ b/cddl/debug-status.cddl
@@ -10,5 +10,5 @@ ds-enabled                     = JC< "enabled", 0 >
 disabled                       = JC< "disabled", 1 >
 disabled-since-boot            = JC< "disabled-since-boot", 2 >
 disabled-permanently           = JC< "disabled-permanently", 3 >
-disabled-fully-and-permanently = JC< "disabled-fully-and-permanently",
-                                      4 >
+disabled-fully-and-permanently = 
+                       JC< "disabled-fully-and-permanently", 4 >

--- a/cddl/external/jwt.cddl
+++ b/cddl/external/jwt.cddl
@@ -4,7 +4,8 @@
 ; separated by a ".". This CDDL simply matches top-level syntax of of
 ; a JWS or JWE since it is not possible to do more in CDDL.
 
-JWT-Message = text .regexp "[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+"
+JWT-Message =
+   text .regexp "[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+"
 
 
 ; Note that the payload of a JWT is defined in claims-set.cddl. That 

--- a/cddl/nested-token-cbor.cddl
+++ b/cddl/nested-token-cbor.cddl
@@ -1,7 +1,8 @@
 ; This is an EAT token that is nested inside a CBOR token.  When this
 ; occurs some means is needed to identify the type of token (signed,
-; unsigned or detached EAT bundle) and the encoding format (JSON or CBOR). This is the
-; only place in EAT where JSON can appear in a CBOR token.
+; unsigned or detached EAT bundle) and the encoding format (JSON or
+; CBOR). This is the only place in EAT where JSON can appear in a CBOR
+; token.
 ;
 ; The nested token may be one of these:
 ;- A CWT format token

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -79,6 +79,7 @@ normative:
   RFC8259:
   RFC8392:
   RFC8610:
+  RFC8792:
   RFC3986:
   RFC9052:
   RFC9090:
@@ -2165,8 +2166,10 @@ It informs the relying party that they were correct in the "measres" claim.
 
 ### JSON-encoded Token with Sumodules
 
+This example has its lines wrapper per {{RFC8792}}.
+
 ~~~~
-{::include cddl/Example-Payloads/submods.json}
+{::include cddl/Example-Payloads/submods.json_f}
 ~~~~
 
 
@@ -2206,8 +2209,10 @@ In this bundle there are two detached Claims-Sets, "CS1" and "CS2".
 The JWT at the start of the bundle has detached signature submodules with hashes of "CS1" and "CS2".
 TODO: make the JWT actually be correct verifiable JWT.
 
+This example has its lines wrapper per {{RFC8792}}.
+
 ~~~~
-{::include cddl/Example-Tokens/deb.json}
+{::include cddl/Example-Tokens/deb.json_f}
 ~~~~
 
 
@@ -2606,6 +2611,11 @@ differences. A comprehensive history is available via the IETF Datatracker's rec
 - Largely rewrite the first paragraphs in section 1, the introduction
 - Mention $$Claims-Set-Claims in prose and require future claims be in CDDL
 - Add Carl Wallace as an author
+
+## From draft-ietf-rats-eat-15
+- Repair all too-long lines
+- Remove tabs from examples
+
 
 --- contributor
 


### PR DESCRIPTION
JSON examples use RFC 8792 folding.

Other long lines were shortened in the original CBOR diag and CDDL.

There should be no more build warnings about long lines.

There still are build warnings for tabs because some of the external references have tabs.

Address #288