### PR TITLE
Some sockets should have been types, not groups

### DIFF
--- a/cddl/Example-Payloads/valid_iot.diag
+++ b/cddl/Example-Payloads/valid_iot.diag
@@ -14,7 +14,7 @@
                         "OS" : {
         / secboot /         262: true,
         / dbgstat /         263: 2, / disabled-since-boot /
-        / measurements      274: [
+        / measurements /    274: [
                                    [
                                      121, / CoAP Content ID. A     /
                                           / made up one until one  /

--- a/cddl/eat-cbor.cddl
+++ b/cddl/eat-cbor.cddl
@@ -1,7 +1,7 @@
-EAT-CBOR-Token = $$EAT-CBOR-Tagged-Token / $$EAT-CBOR-Untagged-Token 
+EAT-CBOR-Token = $EAT-CBOR-Tagged-Token / $EAT-CBOR-Untagged-Token
 
-$$EAT-CBOR-Tagged-Token /= CWT-Tagged-Message
-$$EAT-CBOR-Tagged-Token /= BUNDLE-Tagged-Message
+$EAT-CBOR-Tagged-Token /= CWT-Tagged-Message
+$EAT-CBOR-Tagged-Token /= BUNDLE-Tagged-Message
 
-$$EAT-CBOR-Untagged-Token /= CWT-Untagged-Message
-$$EAT-CBOR-Untagged-Token /= BUNDLE-Untagged-Message
+$EAT-CBOR-Untagged-Token /= CWT-Untagged-Message
+$EAT-CBOR-Untagged-Token /= BUNDLE-Untagged-Message

--- a/cddl/measurements.cddl
+++ b/cddl/measurements.cddl
@@ -6,8 +6,8 @@ measurements-type = [+ measurements-format]
 
 measurements-format = [
     content-type:   coap-content-format,
-    content-format: JC< $$measurements-body-json,
-                        $$measurements-body-cbor > 
+    content-format: JC< $measurements-body-json,
+                        $measurements-body-cbor >
 ]
 
 ; The JSON and CBOR types for CoSWID. CoSWIDs are of course alwas in
@@ -16,7 +16,7 @@ measurements-format = [
 ; untagged-coswid encoded in CBOR as usual, but then wrapped with B64
 ; encoding.
 ;
-$$measurements-body-cbor /= bytes .cbor untagged-coswid
-$$measurements-body-json /= base64-url-text
+$measurements-body-cbor /= bytes .cbor untagged-coswid
+$measurements-body-json /= base64-url-text
 
 

--- a/cddl/nested-token-cbor.cddl
+++ b/cddl/nested-token-cbor.cddl
@@ -24,7 +24,7 @@ CBOR-Nested-Token =
 
 ; The CBOR tag mechanism is used to select between the various types
 ; of CBOR encoded tokens.
-CBOR-Token-Inside-CBOR-Token = bstr .cbor $$EAT-CBOR-Tagged-Token
+CBOR-Token-Inside-CBOR-Token = bstr .cbor $EAT-CBOR-Tagged-Token
 
 ; The contents of this text string MUST be a JSON-encoded
 ; JSON-Nested-Token.  See the definition of JSON-Nested-Token.


### PR DESCRIPTION
One might think that something that in CDDL that is an array is a group, but it's not. It's a type. It's only a group if it hasn't yet been turned into an array. Same for maps.
