### PR TITLE
Remove sentence about section 4 claims passing through

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -2518,10 +2518,8 @@ The following is a list of known changes since the immediately previous drafts. 
 non-authoritative.  It is meant to help reviewers see the significant
 differences. A comprehensive history is available via the IETF Datatracker's record for this document.
 
-## From draft-ietf-rats-eat-17
-- Rename secboot to oemboot and describe it as OEM Authorized Boot
-- Replace use of "attestations" in intended use claim
-- Be clear about nonce providing freshness and replay protection in privacy considerations section
+## From draft-ietf-rats-eat-18
+- Remove sentence discussing pass through of claims about the token in section 4.3
 
 --- contributor
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1149,10 +1149,7 @@ Thus, a CBOR-encoded EAT can have a JSON-encoded EAT as a nested token and vice 
 ## Claims Describing the Token
 
 The claims in this section provide meta data about the token they occur in.
-They do not describe the entity.
-
-They may appear in evidence or attestation results.
-When these claims appear in evidence, they SHOULD NOT be passed through the verifier into attestation results.
+They do not describe the entity. They may appear in evidence or attestation results.
 
 
 ### iat (Timestamp) Claim


### PR DESCRIPTION
The idea is to be silent on this because who ever builds a system that might or might not pass these claims through will probably know more than we do.

To me, there are clearly cases were these claims might pass through and clearly cases where they won't. For example the verifier might be a light-touch verifier only doing the signature verification so it makes sense to pass through intended use and profile. In other cases the evidence token and attestation results token might be completely different in nature. I don't see what value we can add by speculating about this.

The discussion in 1.3, particularly 1.3.1 applies here. I think that's all we need to say.

I don't see any security risks by being silent here. There's no obvious attacks that might happen if these are passed through.
 