### PR TITLE
Remove hash-based OEMID

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -138,11 +138,6 @@ normative:
 
   SUIT.Manifest: I-D.ietf-suit-manifest
 
-  SHS:
-    title: Secure Hash Standard (SHS)
-    target: https://csrc.nist.gov/publications/detail/fips/180/4/final
-    date: August 2015
-
 
 informative:
   RFC4122:
@@ -2489,6 +2484,7 @@ differences. A comprehensive history is available via the IETF Datatracker's rec
 - Prefer the term "encoding" over "format" when referring to CBOR and JSON.
 - Separate sections for creating and consuming UEIDs
 - Base location on W3C reference directly and WGS84 indirectly
+- The option for a hash-based OEMID is removed
 
 
 --- contributor

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -597,10 +597,6 @@ They would perform this only once in the life of the company to generate the sin
 They would use that same ID in every entity they make.
 This uniquely identifies the OEM on a statistical basis and is large enough should there be ten billion companies.
 
-The OEM MAY also use a hash function like SHA-256 and truncate the output to 128 bits.
-The input to the hash should be somethings that have at least 96 bits of entropy, but preferably 128 bits of entropy.
-The input to the hash MAY be something whose uniqueness is managed by a central registry like a domain name.
-
 In JSON format tokens this MUST be base64url encoded.
 
 #### IEEE Based OEMID


### PR DESCRIPTION
The hash-based OEMID is removed because I think many may get it wrong and it is hard to explain how to get it right.

The input to the hash needs to identify the OEM globally.  The text about 96 bits of entropy is confusing. It's not 96 bits as in the output of an RNG. It's 96 bits in some space of global OEM identifiers.

The one use I can think of for it is when the the device has a domain name of the OEM handy. They can run that through the hash and get a good globally unique OEM ID. The uniqueness is coming from the fact that domain names are managed to be globally unique by a central authority.

But maybe we should just have an OEM ID type that is a DNS name or the hash of a DNS name?

