### PR TITLE
Expand on difference between authentiation and attestation

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -207,8 +207,8 @@ For example, partial trust may be allowing a monetary transaction only up to a l
 
 The security model and goal for attestation are unique and are not the same as for other security standards like those for server authentication, user authentication and secured messaging.
 To give an example of one aspect of the difference, consider the association and life-cycle of key material.
-For authentication keys are associated with a user or service and set up by actions performed by a user or an operator of a service.
-For attestation the keys are associated with specific devices and are configured by device manufacturers.
+For authentication, keys are associated with a user or service and set up by actions performed by a user or an operator of a service.
+For attestation, the keys are associated with specific devices and are configured by device manufacturers.
 The reader is assumed to be familiar with the goals and security model for attestation as described in {{RATS.Architecture}} and are not repeated here.
 
 This document defines some common claims that are potentially of broad use.

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -206,7 +206,10 @@ The relying party may choose to trust, not trust or partially trust the entity.
 For example, partial trust may be allowing a monetary transaction only up to a limit.
 
 The security model and goal for attestation are unique and are not the same as for other security standards like those for server authentication, user authentication and secured messaging.
-The reader is assumed to be familiar with the goals and security model for attestation as described in {{RATS.Architecture}}.
+To give an example of one aspect of the difference, consider the association and life-cycle of key material.
+For authentication keys are associated with a user or service and set up by actions performed by a user or an operator of a service.
+For attestation the keys are associated with specific devices and are configured by device manufacturers.
+The reader is assumed to be familiar with the goals and security model for attestation as described in {{RATS.Architecture}} and are not repeated here.
 
 This document defines some common claims that are potentially of broad use.
 EAT additionally allows proprietary claims and for further claims to be standardized.


### PR DESCRIPTION
I'm trying to convey this: if you the reader do not understand the security model for attestation, you should go read about it elsewhere to help you understand EAT.

I'm trying to use contrast with authentication to make that point. I'm not sure if it is working. Maybe a different approach would work better? 

How about this?

> In the payment example just mentioned, the payment limit from limited trust is because of limited security of the payment terminal, phone or device used to make the payment, not the user's credit rating or bank account balance.

I also do not wish to put a definition of the attestation security model in EAT. EAT is just a protocol document. The RATS architecture document is where the attestation security model is defined.  If we had to, we could put a definition of the attestation security model in EAT, but I would want it in an appendix.


