### PR TITLE
Remove registration and other use of SPDX and CycloneDX

### DIFF
--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -30,6 +30,3 @@ $manifest-body-json /= base64-url-text
 $manifest-body-cbor /= bytes .cbor SUIT_Envelope
 $manifest-body-json /= base64-url-text
 
-
-; TODO: remove this when SUIT CDDL gets fixed
-suit-directive-process-dependency = 19

--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -31,24 +31,5 @@ $manifest-body-cbor /= bytes .cbor SUIT_Envelope
 $manifest-body-json /= base64-url-text
 
 
-; Only the JSON SPDX format is supported since it is the only one for
-; which a content type is registered.
-
-$manifest-body-cbor /= spdx-json
-$manifest-body-json /= spdx-json
-
-spdx-json = text
-
-
-; CycloneDX in XML or JSON format
-
-$manifest-body-cbor /= cyclone-dx-json
-$manifest-body-cbor /= cyclone-dx-xml
-$manifest-body-json /= cyclone-dx-json
-$manifest-body-json /= cyclone-dx-xml
-cyclone-dx-json = text
-cyclone-dx-xml  = text
-
-
 ; TODO: remove this when SUIT CDDL gets fixed
 suit-directive-process-dependency = 19

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -122,17 +122,6 @@ normative:
 
   IANA.cbor-tags:
 
-  SPDX:
-    title: Software Package Data Exchange (SPDX)
-    target: https://spdx.dev/wp-content/uploads/sites/41/2020/08/SPDX-specification-2-2.pdf
-    date: 2020
-
-  CycloneDX:
-     title: CycloneDX
-     target: https://cyclonedx.org/specification/overview/
-     date: false
-
-
   IANA.core-parameters:
 
   SUIT.Manifest: I-D.ietf-suit-manifest
@@ -919,8 +908,6 @@ In some cases EAT submodules may be used instead of the array structure in this 
 When the {{CoSWID}} format is used, it MUST be a payload CoSWID, not an evidence CoSWID.
 
 A {{SUIT.Manifest}} may be used as a manifest.
-
-This document registers CoAP Content Formats for CycloneDX {{CycloneDX}} and SPDX {{SPDX}} so they can be used as a manifest.
 
 This claim is extensible for use of manifest formats beyond those mentioned in this document.
 No particular manifest format is preferred.
@@ -1961,29 +1948,6 @@ specification reference.
 | Tag    | Data Items     | Semantics                   |
 | TBD602 | array          | Detached EAT Bundle {{DEB}} |
 
-
-## Media Types Registered by this Document
-
-It is requested that the CoAP Content-Format for SPDX and CycloneDX be been registered in the "CoAP Content-Formats" subregistry within the "Constrained RESTful Environments (CoRE) Parameters" registry [IANA.core-parameters]:
-
-* Media Type: application/spdx+json
-* Encoding: binary
-* ID: TBD
-* Reference: {{SPDX}}
-
-&nbsp;
-
-* Media Type: vendor/vnd.cyclonedx+xml
-* Encoding: binary
-* ID: TBD
-* Reference: {{CycloneDX}}
-
-&nbsp;
-
-* Media Type: vendor/vnd.cyclonedx+json
-* Encoding: binary
-* ID: TBD
-* Reference: {{CycloneDX}}
 
 --- back
 


### PR DESCRIPTION
This doesn't preclude the user of SPDX and CycloneDX at all. Manifests is a pluggable claim so any SBOM can be used as long as a CoAP content type is registered for it.

It seems that these registrations are better done elsewhere and by people expert with these two SBOMs.

This also simplifies and shortens the EAT draft which is a good thing.