### PR TITLE
Fix UEID length and add simple example to intro

### DIFF
--- a/cddl/Example-Payloads/simple.json
+++ b/cddl/Example-Payloads/simple.json
@@ -1,0 +1,7 @@
+{
+    "eat_nonce": "MIDBNH28iioisjPy",
+    "ueid":      "xoXC8AGPJxM",
+    "oemid":     76543, 
+    "swname":    "Acme IoT OS",
+    "swversion": "3.1.4"
+}

--- a/cddl/Example-Payloads/simple.json
+++ b/cddl/Example-Payloads/simple.json
@@ -1,6 +1,6 @@
 {
     "eat_nonce": "MIDBNH28iioisjPy",
-    "ueid":      "xoXC8AGPJxM",
+    "ueid":      "AgAEizrK3Q",
     "oemid":     76543, 
     "swname":    "Acme IoT OS",
     "swversion": "3.1.4"

--- a/cddl/ueid.cddl
+++ b/cddl/ueid.cddl
@@ -1,3 +1,3 @@
 $$Claims-Set-Claims //= (ueid-label => ueid-type)
 
-ueid-type = JC<base64-url-text .size (12..44) , bstr .size (7..33)>
+ueid-type = JC<base64-url-text .size (10..44) , bstr .size (7..33)>

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -225,6 +225,23 @@ An EAT may be encoded in either JavaScript Object Notation (JSON) {{RFC8259}} or
 EAT is built on CBOR Web Token (CWT) {{RFC8392}} and JSON Web Token (JWT) {{RFC7519}} and inherits all their characteristics and their security mechanisms.
 Like CWT and JWT, EAT does not imply any message flow.
 
+Following is a very simple example.
+It is JSON format for easy reading, but could also be CBOR.
+Only the Claims-Set, the payload for the JWT, is shown.
+
+~~~~
+{::include cddl/Example-Payloads/simple.json}
+~~~~
+
+This example has a nonce for freshness.
+This nonce is the base64 encoding of a 12 byte random binary byte string.
+The ueid is effectively a serial number uniquely identifying the device.
+This ueid is the base64 encoding of a 48-bit MAC address.
+The oemid identifies the manufacturer using a Private Enterprise Number {{PEN}}.
+The SW is identified by a simple string name and version.
+It could be identified by a full manifest, but this is a minimal example.
+
+
 ## Entity Overview
 
 This document uses the term "entity" to refer to the target of an EAT.

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -238,7 +238,7 @@ This nonce is the base64 encoding of a 12 byte random binary byte string.
 The ueid is effectively a serial number uniquely identifying the device.
 This ueid is the base64 encoding of a 48-bit MAC address.
 The oemid identifies the manufacturer using a Private Enterprise Number {{PEN}}.
-The SW is identified by a simple string name and version.
+The software is identified by a simple string name and version.
 It could be identified by a full manifest, but this is a minimal example.
 
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -234,9 +234,9 @@ Only the Claims-Set, the payload for the JWT, is shown.
 ~~~~
 
 This example has a nonce for freshness.
-This nonce is the base64 encoding of a 12 byte random binary byte string.
+This nonce is the base64url encoding of a 12 byte random binary byte string.
 The ueid is effectively a serial number uniquely identifying the device.
-This ueid is the base64 encoding of a 48-bit MAC address.
+This ueid is the base64url encoding of a 48-bit MAC address preceded by the type byte 0x02.
 The oemid identifies the manufacturer using a Private Enterprise Number {{PEN}}.
 The software is identified by a simple string name and version.
 It could be identified by a full manifest, but this is a minimal example.


### PR DESCRIPTION
A 48-bit mac address formats to 7 binary bytes. b64url encoding of 7 bytes is 10 bytes, not 12. The previous mistake was to include the padding for b64 encoding which is not present with b64 encoding.

Warren Kumari suggested a simple example be added early in the document as part of the larger review. Seems like a good idea! Make it easier for people to understand that aren't very familiar with attestation, which is a lot of people since attestation is not widely used yet.