### PR TITLE
Types in CWT registry are all CDDL definitions

### DIFF
--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1802,6 +1802,7 @@ The "Claim Name" is as defined for the CWT registry, not the JWT registry.
 The "JWT Claim Name" is equivalent to the "Claim Name" in the JWT registry.
 
 IANA is requested to register the following claims.
+The "Claim Value Type(s)" here all name CDDL definitions and are only for the CWT registry.
 
 [^remove]
 
@@ -1818,7 +1819,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Nonce
 * JWT Claim Name: "eat_nonce"
 * Claim Key: 10
-* Claim Value Type(s): byte string
+* Claim Value Type(s): bstr or array
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1848,7 +1849,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Hardware OEM ID
 * JWT Claim Name: "oemid"
 * Claim Key: 258
-* Claim Value Type(s): byte string or integer
+* Claim Value Type(s): bstr or int
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1874,11 +1875,11 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 
 &nbsp;
 
-* Claim Name: OEM Authorised Boot
+* Claim Name: OEM Authorized Boot
 * Claim Description: Indicates whether the software booted was OEM authorized
 * JWT Claim Name: "oemboot"
 * Claim Key: 262
-* Claim Value Type(s): Boolean
+* Claim Value Type(s): bool
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1888,7 +1889,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Indicates status of debug facilities
 * JWT Claim Name: "dbgstat"
 * Claim Key: 263
-* Claim Value Type(s): integer or string
+* Claim Value Type(s): uint
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1908,7 +1909,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Indicates the EAT profile followed
 * JWT Claim Name: "eat_profile"
 * Claim Key: 265
-* Claim Value Type(s): URI or OID
+* Claim Value Type(s): uri or oid
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1928,7 +1929,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Uptime
 * JWT Claim Name: "uptime"
 * Claim Key: TBD
-* Claim Value Type(s): unsigned integer
+* Claim Value Type(s): uint
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1948,7 +1949,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Identifies a boot cycle
 * JWT Claim Name: "bootseed"
 * Claim Key: TBD
-* Claim Value Type(s): bytes
+* Claim Value Type(s): bstr
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1968,7 +1969,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: The name of the software running in the entity
 * JWT Claim Name: "swname"
 * Claim Key: TBD
-* Claim Value Type(s): map
+* Claim Value Type(s): tstr
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1978,7 +1979,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: The version of software running in the entity
 * JWT Claim Name: "swversion"
 * Claim Key: TBD
-* Claim Value Type(s): map
+* Claim Value Type(s): array
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -2018,7 +2019,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Indicates intended use of the EAT
 * JWT Claim Name: "intuse"
 * Claim Key: TBD
-* Claim Value Type(s): integer or string
+* Claim Value Type(s): uint
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -2550,11 +2551,9 @@ The following is a list of known changes since the immediately previous drafts. 
 non-authoritative.  It is meant to help reviewers see the significant
 differences. A comprehensive history is available via the IETF Datatracker's record for this document.
 
-## From draft-ietf-rats-eat-22
-- Reference RFC 9393 instead of CoSWID draft
-- Wording improvement for "oid" CDDL tag
-- Fix RFC Editor/IANA instructions for examples
-- Improve CDDL for JSON-selector
+## From draft-ietf-rats-eat-24
+- Use only CDDL definition names for "Claim Value Type" column in CWT claim registry
+- Correct the "Claim Value Type" for some claims
 
 --- contributor
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1469,9 +1469,9 @@ This section gives a normative definition of one profile that is good for many c
 
 The identifier for this profile is "urn:ietf:rfc:rfcTBD".
 
-[^to-be-removed]
+[^to-be-removed-1]
 
-[^to-be-removed]: RFC Editor: please replace rfcTBD with this RFC number and remove this note.
+[^to-be-removed-1]: RFC Editor: please replace rfcTBD with this RFC number and remove this note.
 
 | Issue | Profile Definition |
 | CBOR/JSON | CBOR MUST be used  |
@@ -2058,7 +2058,9 @@ Most examples are shown as just a Claims-Set that would be a payload for a CWT, 
 The signing is left off so the Claims-Set is easier to see.
 Some examples of signed tokens are also given.
 
-[^to-be-removed]: RFC Editor: When the IANA values are permanently assigned, please contact the authors so the examples can be regenerated. Regeneration is required because IANA-assigned values are inside hex and based-64 encoded data and some of these are signed.
+[^to-be-removed-2]
+
+[^to-be-removed-2]: RFC Editor: When the IANA values are permanently assigned, please contact the authors so the examples can be regenerated. Regeneration is required because IANA-assigned values are inside hex and based-64 encoded data and some of these are signed.
 
 ## Claims Set Examples
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1533,9 +1533,9 @@ This makes use of the types defined in {{RFC8610}} Appendix D, Standard Prelude.
 time-int is identical to the epoch-based time, but disallows
 floating-point representation.
 
-For CBOR-encoded tokens, OIDs are specified by "oid" in {{RFC9090}}.
+For CBOR-encoded tokens, OIDs are specified using the CDDL type name "oid" from {{RFC9090}}.
 They are encoded without the tag number.
-For CBOR-encoded tokens, OIDs are a text string in the common form of "nn.nn.nn...".
+For JSON-encoded tokens, OIDs are a text string in the common form of "nn.nn.nn...".
 
 Unless expliclity indicated, URIs are not the URI tag defined in {{RFC8949}}.
 They are just text strings that contain a URI conforming to the format defined in {{RFC3986}}.

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1804,9 +1804,9 @@ The "JWT Claim Name" is equivalent to the "Claim Name" in the JWT registry.
 IANA is requested to register the following claims.
 The "Claim Value Type(s)" here all name CDDL definitions and are only for the CWT registry.
 
-[^remove]
+[^to-be-removed-3]
 
-[^remove]: RFC editor: please see instructions in followg paragraph and remove for final publication
+[^to-be-removed-3]: RFC editor: please see instructions in followg paragraph and remove for final publication
 
 RFC Editor: Please make the following adjustments and remove this paragraph.
 Replace "__this document__" with this RFC number.


### PR DESCRIPTION
See https://mailarchive.ietf.org/arch/msg/cbor/qMs19DfPFSOrQ-e0tRHk-3Zaer4/

The "Claim Value Type(s)" column is now all CDDL definitions.

Some of the types were in error and corrected.

This only affected the IANA section and only parts of it that aren't really normative.