### PR TITLE
Remove SUIT reference entirely to break dependency

### DIFF
--- a/cddl/manifests.cddl
+++ b/cddl/manifests.cddl
@@ -23,10 +23,3 @@ manifest-format = [
 $manifest-body-cbor /= bytes .cbor untagged-coswid
 $manifest-body-json /= base64-url-text
 
-
-; A SUIT manifest is always CBOR, so the same is done for it as is
-; done for a CoSWID.
-
-$manifest-body-cbor /= bytes .cbor SUIT_Envelope
-$manifest-body-json /= base64-url-text
-

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -154,8 +154,6 @@ informative:
 
   UCCS: I-D.ietf-rats-uccs
 
-  SUIT.Manifest: I-D.ietf-suit-manifest
-
   JTAG:
     title: IEEE Standard for Reduced-Pin and Enhanced-Functionality Test Access Port and Boundary-Scan Architecture
     target: https://ieeexplore.ieee.org/document/5412866
@@ -936,8 +934,6 @@ In some cases EAT submodules may be used instead of the array structure in this 
 A CoSWID manifest MUST be a payload CoSWID, not an evidence CoSWID.
 These are defined in {{RFC9393}}.
 
-A Software Updates for Internet of Things (SUIT) Manifest {{SUIT.Manifest}} may be used.
-
 This claim is extensible for use of manifest formats beyond those mentioned in this document.
 No particular manifest format is preferred.
 For manifest interoperability, an EAT profile as defined in {{profiles}}, should be used to specify which manifest format(s) are allowed.
@@ -1447,7 +1443,7 @@ A profile may constrain the definition of claims that are defined in this docume
 For example, a profile may require the EAT nonce be a certain length or the "location" claim always include the altitude.
 
 Some claims are "pluggable" in that they allow different formats for their content.
-The "manifests" claim ({{manifests}}) along with the measurement and "measurements" ({{measurements}}) claims are examples of this, allowing the use of CoSWID, SUIT Manifest and other formats.
+The "manifests" claim ({{manifests}}) along with the measurement and "measurements" ({{measurements}}) claims are examples of this, allowing the use of CoSWID and other formats.
 A profile should specify which formats are allowed to be sent, with the assumption that the corresponding CoAP content types have been registered.
 A profile should require the receiver to accept all formats that are allowed to be sent.
 
@@ -2545,10 +2541,9 @@ The following is a list of known changes since the immediately previous drafts. 
 non-authoritative.  It is meant to help reviewers see the significant
 differences. A comprehensive history is available via the IETF Datatracker's record for this document.
 
-## From draft-ietf-rats-eat-24
-- Use only CDDL definition names for "Claim Value Type" column in CWT claim registry
-- Correct the "Claim Value Type" for some claims
-- Make SUIT reference informative (it use is optional in an optional claim)
+## From draft-ietf-rats-eat-25
+- Remove reference to SUIT Manifest entirely to break dependency (SUIT manifest can reference EAT).
+
 
 --- contributor
 

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -1823,7 +1823,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: The Universal Entity ID
 * JWT Claim Name: "ueid"
 * CWT Claim Key: 256
-* Claim Value Type(s): byte string
+* Claim Value Type(s): bstr
 * Change Controller: IETF
 * Specification Document(s): __this document__
 
@@ -1853,7 +1853,7 @@ Claim 262 should be renamed from "secboot" to "oemboot" in the JWT registry and 
 * Claim Description: Model identifier for hardware
 * JWT Claim Name: "hwmodel"
 * Claim Key: 259
-* Claim Value Type(s): byte string
+* Claim Value Type(s): bstr
 * Change Controller: IETF
 * Specification Document(s): __this document__
 


### PR DESCRIPTION
The suit reference was through a pluggable socket part of the manifests claim. It was in EAT as a convenience. SUIT manifest can still be used and it is obvious how it should work even without any text so there is no big loss here.
