### PR TITLE
Rename EAT-CBOR-Tagged-Token to CBOR-Tagged-Token

### DIFF
--- a/cddl/eat-cbor.cddl
+++ b/cddl/eat-cbor.cddl
@@ -1,7 +1,7 @@
-EAT-CBOR-Token = $EAT-CBOR-Tagged-Token / $EAT-CBOR-Untagged-Token
+EAT-CBOR-Token = $CBOR-Tagged-Token / $EAT-CBOR-Untagged-Token
 
-$EAT-CBOR-Tagged-Token /= CWT-Tagged-Message
-$EAT-CBOR-Tagged-Token /= BUNDLE-Tagged-Message
+$CBOR-Tagged-Token /= CWT-Tagged-Message
+$CBOR-Tagged-Token /= BUNDLE-Tagged-Message
 
 $EAT-CBOR-Untagged-Token /= CWT-Untagged-Message
 $EAT-CBOR-Untagged-Token /= BUNDLE-Untagged-Message

--- a/cddl/submods-cbor.cddl
+++ b/cddl/submods-cbor.cddl
@@ -21,7 +21,7 @@ CBOR-Nested-Token =
 
 ; The CBOR tag mechanism is used to select between the various types
 ; of CBOR encoded tokens.
-CBOR-Token-Inside-CBOR-Token = bstr .cbor $EAT-CBOR-Tagged-Token
+CBOR-Token-Inside-CBOR-Token = bstr .cbor $CBOR-Tagged-Token
 
 ; The contents of this text string MUST be a JSON-encoded
 ; JSON-Selector.  See the definition of JSON-Selector. The

--- a/cddl/submods-json.cddl
+++ b/cddl/submods-json.cddl
@@ -33,7 +33,7 @@ $JSON-Selector /= [type: "DIGEST", nested-token:
   Detached-Submodule-Digest]
 
 ; After the base64url encoding is removed, the contents of this are a
-; $$EAT-CBOR-Tagged-Token (see eat-cbor.cddl) encoded in **CBOR**.
+; $CBOR-Tagged-Token (see eat-cbor.cddl) encoded in **CBOR**.
 ; This is the only transition point in EAT from JSON to CBOR.  For
 ; example, it is a CWT that is a COSE_Sign1 that is a CBOR tag that
 ; has been base64url encoded.

--- a/draft-ietf-rats-eat.md
+++ b/draft-ietf-rats-eat.md
@@ -405,7 +405,7 @@ There is no fixed mechanism across all use cases.
 This document also defines another message, the detached EAT bundle (see {{DEB}}), which holds a collection of detached claims sets and an EAT that provides integrity and authenticity protection for them.
 Detached EAT bundles can be either CBOR or JSON encoded.
 
-The following CDDL defines the top-level `$EAT-CBOR-Tagged-Token`, `$EAT-CBOR-Untagged-Token` and `$EAT-JSON-Token-Formats` sockets (see {{Section 3.9 of -cddl}}), enabling future token formats to be defined.
+The following CDDL defines the top-level `$CBOR-Tagged-Token`, `$EAT-CBOR-Untagged-Token` and `$EAT-JSON-Token-Formats` sockets (see {{Section 3.9 of -cddl}}), enabling future token formats to be defined.
 Any new format that plugs into one or more of these sockets MUST be defined by an IETF standards action.
 Of particular use may be a token type that provides no direct authenticity or integrity protection for use with transports mechanisms that do provide the necessary security services {{UCCS}}.
 
@@ -1063,7 +1063,7 @@ The Detached-Submodule-Digest type is defined as follows:
 Nested tokens can be one of three types as defined in this document or types standardized in follow-on documents (e.g., {{UCCS}}).
 Nested tokens are the only mechanism by which JSON can be embedded in CBOR and vice versa.
 
-The addition of further types is accomplished by augmenting the $EAT-CBOR-Tagged-Token socket or the $JSON-Selector socket.
+The addition of further types is accomplished by augmenting the $CBOR-Tagged-Token socket or the $JSON-Selector socket.
 
 When decoding a JSON-encoded EAT, the type of submodule is determined as follows.
 A JSON object indicates the submodule is a Claims-Set.


### PR DESCRIPTION
This is renamed because the tagged token contained might not be EAT format. For example it could be from draft-ietf-rats-msg-wrap.

There is no need to change anything else to accommodate draft-ietf-rats-msg-wrap. The socket name was just misleading.