### PR TITLE
remove JC-NEST-SAFE

### DIFF
--- a/cddl/deb.cddl
+++ b/cddl/deb.cddl
@@ -8,8 +8,8 @@ BUNDLE-Untagged-Message = Detached-EAT-Bundle
 Detached-EAT-Bundle = [
     main-token : Nested-Token,
     detached-claims-sets: {
-        + tstr => JC-NEST-SAFE<json-wrapped-claims-set,
-                               cbor-wrapped-claims-set>
+        + tstr => JC<json-wrapped-claims-set,
+                     cbor-wrapped-claims-set>
     }
 ]
 

--- a/cddl/external/claims-set.cddl
+++ b/cddl/external/claims-set.cddl
@@ -28,7 +28,3 @@ CBOR-ONLY<C> = C .feature "cbor"
 
 JC<J,C> = JSON-ONLY<J> / CBOR-ONLY<C>
 
-; Same as JC<> but with unwound generic nesting as it seems to cause
-; problems. Perhaps this is the nesting problem described in RFC 
-; 8610.
-JC-NEST-SAFE<J,C> = J .feature "json" / C .feature "cbor"


### PR DESCRIPTION
Enough time has past to not worry about old versions of the cddl tool