### PR TITLE
Make cddl form for oemid consistent

### DIFF
--- a/cddl/oemid.cddl
+++ b/cddl/oemid.cddl
@@ -1,6 +1,7 @@
 $$Claims-Set-Claims //= (
-    oemid-label => oemid-pen / oemid-ieee / oemid-random
+    oemid-label => oemid-type
 )
+oemid-type = oemid-pen / oemid-ieee / oemid-random
 
 oemid-pen = int
 


### PR DESCRIPTION
The value for all claims is of the form "xxxx-type" except oemid. This fixes it.

The cddl works fine without this change. It's just an inconsistency.
